### PR TITLE
Fix issue where pending transactions don't transition to failed becau…

### DIFF
--- a/CRM/eWAYRecurring/Utils.php
+++ b/CRM/eWAYRecurring/Utils.php
@@ -119,6 +119,10 @@ class CRM_eWAYRecurring_Utils {
           'contribution_status_id' => 'Failed',
         ]);
 
+        // Update queue accordingly
+        $transactionPendingMaxTries['status'] = self::STATUS_FAILED;
+        civicrm_api3('EwayContributionTransactions', 'create', $transactionPendingMaxTries);
+
       } catch (CiviCRM_API3_Exception $e) {
       // Contribution not found.
       }

--- a/info.xml
+++ b/info.xml
@@ -15,8 +15,8 @@
     <email>support@agileware.com.au</email>
   </maintainer>
   <develStage>stable</develStage>
-  <releaseDate>2025-01-15</releaseDate>
-  <version>2.6.8</version>
+  <releaseDate>2025-02-21</releaseDate>
+  <version>2.6.8.1</version>
   <compatibility>
     <ver>5.70</ver>
   </compatibility>


### PR DESCRIPTION
…se they don't get removed from the queue

So what happens here is that only the first 25 Pending transactions (which then get abandoned) in the `civicrm_eway_contribution_transactions` table get processed. Ever.

What's supposed to happen is after seven attempts to verify the transaction with Eway, the transaction should be marked as failed. However, unfortunately, the transaction is then not removed from the queue of transactions to be processed.

This PR fixes that issue. Not tested.